### PR TITLE
Add support for ensembldb EnsDb databases to annotatePeak

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ChIPseeker
 Type: Package
 Title: ChIPseeker for ChIP peak Annotation, Comparison, and Visualization
-Version: 1.23.2
+Version: 1.23.3
 Authors@R: c( person(given = "Guangchuang", family = "Yu",       email = "guangchuangyu@gmail.com",      role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
               person(given = "Yun",         family = "Yan",      email = "youryanyun@gmail.com",         role = "ctb"),
               person(given = "Hervé",       family = "Pagès",    email = "hpages@fredhutch.org",         role  = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,4 +67,4 @@ VignetteBuilder: knitr
 ByteCompile: true
 License: Artistic-2.0
 biocViews: Annotation, ChIPSeq, Software, Visualization, MultipleComparison
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ChIPseeker 1.23.3
+
++ Add support for `EnsDb` annotation databases in `annotatePeak`. 
+
 # ChIPseeker 1.23.1
 
 + update GEO data (51079/762820 GSM) (2019-12-20, Fri)

--- a/R/annotatePeak.R
+++ b/R/annotatePeak.R
@@ -174,12 +174,36 @@ annotatePeak <- function(peak,
         colnames(nearestFeatures.df)[1:5] <- c("geneChr", "geneStart", "geneEnd",
                                           "geneLength", "geneStrand")
     } else if (level == "transcript") {
-        colnames(nearestFeatures.df) <- c("geneChr", "geneStart", "geneEnd",
-                                          "geneLength", "geneStrand", "geneId", "transcriptId")
-        nearestFeatures.df$geneId <- TXID2EG(as.character(nearestFeatures.df$geneId), geneIdOnly=TRUE)
+        if (is(TxDb, "EnsDb")) {
+            nearestFeatures.df <- nearestFeatures.df[, c("seqnames", "start",
+                                                         "end", "width",
+                                                         "strand", "gene_id",
+                                                         "tx_id", "tx_biotype"),
+                                                     drop = FALSE]
+            colnames(nearestFeatures.df) <- c(
+                "geneChr", "geneStart", "geneEnd", "geneLength", "geneStrand",
+                "geneId", "transcriptId", "transcriptBiotype")
+        } else {
+            colnames(nearestFeatures.df) <- c("geneChr", "geneStart", "geneEnd",
+                                              "geneLength", "geneStrand",
+                                              "geneId", "transcriptId")
+            nearestFeatures.df$geneId <- TXID2EG(
+                as.character(nearestFeatures.df$geneId), geneIdOnly=TRUE)
+        }
     } else {
-        colnames(nearestFeatures.df) <- c("geneChr", "geneStart", "geneEnd",
-                                          "geneLength", "geneStrand", "geneId")
+        if (is(TxDb, "EnsDb")) {
+            nearestFeatures.df <- nearestFeatures.df[, c("seqnames", "start",
+                                                         "end", "width",
+                                                         "strand", "gene_id",
+                                                         "gene_biotype"),
+                                                     drop = FALSE]
+            colnames(nearestFeatures.df) <- c("geneChr", "geneStart", "geneEnd",
+                                              "geneLength", "geneStrand",
+                                              "geneId", "geneBiotype")
+        } else
+            colnames(nearestFeatures.df) <- c("geneChr", "geneStart", "geneEnd",
+                                              "geneLength", "geneStrand",
+                                              "geneId")
     }
 
     for(cn in colnames(nearestFeatures.df)) {

--- a/R/annotatePeak.R
+++ b/R/annotatePeak.R
@@ -4,7 +4,7 @@
 ##' @title annotatePeak
 ##' @param peak peak file or GRanges object
 ##' @param tssRegion Region Range of TSS
-##' @param TxDb TxDb object
+##' @param TxDb TxDb or EnsDb annotation object
 ##' @param level one of transcript and gene
 ##' @param assignGenomicAnnotation logical, assign peak genomic annotation or not
 ##' @param genomicAnnotationPriority genomic annotation priority

--- a/man/annotatePeak.Rd
+++ b/man/annotatePeak.Rd
@@ -28,7 +28,7 @@ annotatePeak(
 
 \item{tssRegion}{Region Range of TSS}
 
-\item{TxDb}{TxDb object}
+\item{TxDb}{TxDb or EnsDb annotation object}
 
 \item{level}{one of transcript and gene}
 

--- a/vignettes/ChIPseeker.Rmd
+++ b/vignettes/ChIPseeker.Rmd
@@ -167,6 +167,21 @@ peakAnno <- annotatePeak(files[[4]], tssRegion=c(-3000, 3000),
                          TxDb=txdb, annoDb="org.Hs.eg.db")
 ```
 
+Note that it would also be possible to use Ensembl-based `EnsDb` annotation 
+databases created by the `r BiocStyle::Biocpkg("ensembldb")` package for the
+peak annotations by providing it with the `TxDb` parameter. Since UCSC-style 
+chromosome names are used we have to change the style of the chromosome names
+from *Ensembl* to *UCSC* in the example below.
+
+```{r, eval = FALSE}
+library(EnsDb.Hsapiens.v75)
+edb <- EnsDb.Hsapiens.v75
+seqlevelsStyle(edb) <- "UCSC"
+
+peakAnno.edb <- annotatePeak(files[[4]], tssRegion=c(-3000, 3000),
+                             TxDb=edb, annoDb="org.Hs.eg.db")
+```
+
 Peak Annotation is performed by `annotatePeak`. User can define TSS (transcription start site) region, by default TSS is defined from -3kb to +3kb. The output of `annotatePeak` is `csAnno` instance. `r Biocpkg("ChIPseeker")` provides `as.GRanges` to convert `csAnno` to `GRanges` instance, and `as.data.frame` to convert `csAnno` to `data.frame` which can be exported to file by `write.table`.
 
 `TxDb` object contained transcript-related features of a particular genome. Bioconductor provides several package that containing `TxDb` object of model organisms with multiple commonly used genome version, for instance `r Biocannopkg("TxDb.Hsapiens.UCSC.hg38.knownGene")`, `r Biocannopkg("TxDb.Hsapiens.UCSC.hg19.knownGene")` for human genome hg38 and hg19, `r Biocannopkg("TxDb.Mmusculus.UCSC.mm10.knownGene")` and `r Biocannopkg("TxDb.Mmusculus.UCSC.mm9.knownGene")` for mouse genome mm10 and mm9, etc. User can also prepare their own `TxDb` object by retrieving information from UCSC Genome Bioinformatics and BioMart data resources by R function `makeTxDbFromBiomart` and `makeTxDbFromUCSC`. `TxDb` object should be passed for peak annotation.


### PR DESCRIPTION
Add support for `ensembldb` `EnsDb` databases to `annotatePeak`. Fixes also the issue reported in https://support.bioconductor.org/p/129674/