### PR TITLE
Update utilities.R to fix a bug

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -400,7 +400,7 @@ list_to_dataframe <- function(dataList) {
     if (is.null(names(dataList)))
         return(do.call('rbind', dataList))
 
-    cn <- sapply(dataList, colnames) %>% unlist %>% unique
+    cn <- lapply(dataList, colnames) %>% unlist %>% unique
     cn <- c('.id', cn)
     dataList2 <- lapply(seq_along(dataList), function(i) {
         data = dataList[[i]]


### PR DESCRIPTION
This update is to fix bug when using covplot to visualize two or more .bed files.
The bug is also reported in the comments of issue(https://github.com/YuLab-SMU/ChIPseeker/issues/133).
In my opinion, this bug is caused by function(list_to_dataframe), which is a defined function in Package(ChIPseeker)-utilities.R.
So I change a little bit of this function by changing "sapply" to "lapply".
thanks!