### PR TITLE
 bug fixed issue#134 and add function

### DIFF
--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -49,5 +49,6 @@ setGeneric("plotAnnoPie",
                     col=NA,
                     legend.position="rightside",
                     pie3D=FALSE,
+                    radius=0.8,
                     ...)
            standardGeneric("plotAnnoPie"))

--- a/R/csAnno.R
+++ b/R/csAnno.R
@@ -222,8 +222,9 @@ setMethod("plotAnnoPie", signature(x="csAnno"),
                    col=NA,
                    legend.position="rightside",
                    pie3D=FALSE,
+                   radius=0.8,
                    ...){
-              plotAnnoPie.csAnno(x, ndigit, cex, col, legend.position, pie3D, ...)
+              plotAnnoPie.csAnno(x, ndigit, cex, col, legend.position, pie3D, radius, ...)
           })
 
 

--- a/R/plotAnno.R
+++ b/R/plotAnno.R
@@ -57,6 +57,7 @@ plotAnnoBar.data.frame <- function(anno.df,
 ##' @param col color
 ##' @param legend.position topright or other.
 ##' @param pie3D plot in 3D or not
+##' @param radius radius of Pie
 ##' @param ... extra parameter
 ##' @return pie plot of peak genomic feature annotation
 ##' @examples
@@ -72,10 +73,11 @@ plotAnnoBar.data.frame <- function(anno.df,
 ##' @author Guangchuang Yu \url{https://guangchuangyu.github.io}
 plotAnnoPie.csAnno <- function(x,
                         ndigit=2,
-                        cex=0.9,
+                        cex=0.8,
                         col=NA,
                         legend.position="rightside",
                         pie3D=FALSE,
+                        radius=0.8,
                         ...){
 
     anno.df <- getAnnoStat(x)
@@ -86,7 +88,7 @@ plotAnnoPie.csAnno <- function(x,
     if (pie3D)
         annoPie3D(anno.df, ndigit=ndigit, cex=cex, col=col, ...)
 
-    annoPie(anno.df, ndigit=ndigit, cex=cex, col=col, legend.position=legend.position, ...)
+    annoPie(anno.df, ndigit=ndigit, cex=cex, col=col, legend.position=legend.position, radius=radius, ...)
  }
 
 ##' @importFrom RColorBrewer brewer.pal
@@ -96,7 +98,7 @@ plotAnnoPie.csAnno <- function(x,
 ##' @importFrom graphics pie
 ##' @importFrom graphics legend
 ##' @importFrom graphics plot.new
-annoPie <- function(anno.df, ndigit=2, cex=0.9, col=NA, legend.position, ...) {
+annoPie <- function(anno.df, ndigit=2, cex=0.8, col=NA, legend.position, radius=0.8, ...) {
     if ( ! all(c("Feature", "Frequency") %in% colnames(anno.df))) {
         stop("check your input...")
     }
@@ -110,8 +112,9 @@ annoPie <- function(anno.df, ndigit=2, cex=0.9, col=NA, legend.position, ...) {
         layout(matrix(c(1,2), ncol=2), widths=c(0.6,0.4))
         pie(anno.df$Frequency, labels=NA, cex=cex, col=col, ...)
         plot.new()
-        legend("center", legend = labels, fill=col, bty="n")
+        legend("center", legend = labels, fill = col, bty = "n", cex = cex)
     } else {
+        par(mai = c(0,0,0,0))
         pie(anno.df$Frequency,
             ##     ## labels=paste(round(anno.df$Frequency/sum(anno.df$Frequency)*100, 2), "%", sep=""),
             labels=paste(anno.df$Feature, " (",
@@ -119,6 +122,7 @@ annoPie <- function(anno.df, ndigit=2, cex=0.9, col=NA, legend.position, ...) {
                 "%)", sep=""),
             cex=cex,
             col=col,
+            radius=radius,
             ...
             )
     }


### PR DESCRIPTION
This PR is to fix [issue#134](https://github.com/YuLab-SMU/ChIPseeker/issues/134) and it adds two functions to the plotAnno().
The first one is to add cex to legend() in the plotAnnoPie() in order to adjust the size of labels, which can solve the problem of incomplete legends([issue#134](https://github.com/YuLab-SMU/ChIPseeker/issues/134) ).
The second one is to add radius parameter in order to change the size of Pie. The default value of radius is 0.8. This parameter can be used when the legend.position != "rightside"(e.x "topright"). In this situation, plotAnnoPie() will add the annotation on the Pie directly instead of adding them on the rightside. The labels are always long but the size of Pie is too small to hold the annotations and not supported to change under the previous version. I add the radius option for users to change the size of Pie. Users can change the size of the Pie by radius and change the size of labels by cex, which can meet the different needs of Users.
The last change is the default value of cex(from 0.9 to 0.8), which I think is more suitable by my experience of testing painting.