### PR TITLE
Make ncpus configurable for getTagCiMatrix

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -97,14 +97,14 @@ parseBootCiPerc <- function(bootCiPerc){
 ##' @importFrom boot boot
 ##' @importFrom boot boot.ci
 ##' @importFrom parallel detectCores
-getTagCiMatrix <- function(tagMatrix, conf = 0.95, resample=500){
+getTagCiMatrix <- function(tagMatrix, conf = 0.95, resample=500, ncpus=detectCores()-1){
     RESAMPLE_TIME <- resample
     trackLen <- ncol(tagMatrix)
     if (Sys.info()[1] == "Windows") {
         tagMxBoot <- boot(data = tagMatrix, statistic = getSgn, R = RESAMPLE_TIME)
     } else {
         tagMxBoot <- boot(data = tagMatrix, statistic = getSgn, R = RESAMPLE_TIME,
-                          parallel = "multicore", ncpus = detectCores()-1)
+                          parallel = "multicore", ncpus = ncpus)
     }
     cat(">> Running bootstrapping for tag matrix...\t\t",
         format(Sys.time(), "%Y-%m-%d %X"), "\n")


### PR DESCRIPTION
The provided patch makes it possible to use the `ncpus` argument on `plotAvgProf` to configure the number of cores that are used for processing.

```R
# Example usages of `ncpus` argument
 plot <-  plotAvgProf(tagMatrix,
    xlim = c(-3000, 3000),
    conf = 0.95,
    resample = 1000,
    ncpus = 8
)
```

This is related to #110 and possibly #145, since the RAM usage depends heavily on the amount of used cores. Currently it seems to be possible that using `plotAvgProf` with reasonably sized input data terminates on a machine with 8 cores and 32GB of RAM but not on a machine with 16 cores and the same amount of RAM. Limiting the amounts of cores used this might be mitigated.

Please don't hesitate to contact me if there are any questions.