### PR TITLE
bug fix #112 #121 #139

### DIFF
--- a/R/getGenomicAnnotation.R
+++ b/R/getGenomicAnnotation.R
@@ -159,14 +159,14 @@ getGenomicAnnotation <- function(peaks,
     
     peF <- features[idx]
     dd <- ifelse(strand(peF) == "+",
-             start(peaks) - end(peF),
-             end(peaks) - start(peF))
+		 start(peaks) - end(peF),
+		 end(peaks) - start(peF))
     
     if (length(na.idx)) {
         dd2 <- numeric(length(idx) + length(na.idx))
         dd2[-na.idx] <- dd
     } else {
-         dd2 <- dd
+        dd2 <- dd
     }
 
     dsd <- getOption("ChIPseeker.downstreamDistance")

--- a/R/getGenomicAnnotation.R
+++ b/R/getGenomicAnnotation.R
@@ -146,42 +146,63 @@ getGenomicAnnotation <- function(peaks,
 
     ## nearest from gene end
     if (sameStrand) {
-        idx <- precede(peaks, features)
+        idx <- follow(peaks, features)
     } else {
-        idx <- precede(peaks, unstrand(features))
+        idx <- follow(peaks, unstrand(features))
     }
+    
     na.idx <- which(is.na(idx))
     if (length(na.idx)) {
         idx <- idx[-na.idx]
         peaks <- peaks[-na.idx]
     }
+    
     peF <- features[idx]
     dd <- ifelse(strand(peF) == "+",
-                 start(peaks) - end(peF),
-                 end(peaks) - start(peF))
+             start(peaks) - end(peF),
+             end(peaks) - start(peF))
+    
     if (length(na.idx)) {
         dd2 <- numeric(length(idx) + length(na.idx))
         dd2[-na.idx] <- dd
     } else {
-        dd2 <- dd
+         dd2 <- dd
     }
-
-    for (i in 1:3) { ## downstream within 3k
-        j <- which(annotation == "Intergenic" & abs(dd2) <= i*1000 & dd2 != 0)
-        if (length(j) > 0) {
-            if (i == 1) {
-                lbs <- "Downstream (<1kb)"
-            } else {
-                lbs <- paste("Downstream (", i-1, "-", i, "kb)", sep="")
-            }
-            annotation[j] <- lbs
-        }
-    }
-    annotation[which(annotation == "Intergenic")] = "Distal Intergenic"
 
     dsd <- getOption("ChIPseeker.downstreamDistance")
     if (is.null(dsd))
-        dsd <- 3000 ## downstream 3k by default
+	    dsd <- 3000 ## downstream 3k by default
+
+    ## downstream within dsd
+    if(dsd/1000<=1){
+        j <- which(annotation == "Intergenic" & abs(dd2) <= dsd & dd2 != 0)
+        if(length(j)>0){
+            lbs <- paste("Downstream (<=", dsd, "bp)", sep="")
+            annotation[j] <- lbs
+        }
+    }else{
+        
+        ## downstream within 0-dsd/1000 kb
+        for(i in 1:(dsd/1000)){
+            j <- which(annotation == "Intergenic" & abs(dd2) <= i*1000 & dd2 != 0)
+            if (length(j) > 0){
+                if (i == 1){
+                    lbs <- "Downstream (<1kb)"
+                }else{
+                    lbs <- paste("Downstream (", i-1, "-", i, "kb)", sep="")
+                }
+            }
+            annotation[j] <- lbs
+        }
+        
+        ## downstream (dsd/1000) kb - dsd bp
+        z <- which(annotation == "Intergenic" & abs(dd2) <= dsd & dd2 != 0)
+        if(length(z)>0){
+            lbs <- paste("Downstream (",dsd/1000,"kb-", dsd, "bp)", sep="")
+            annotation[z] <- lbs
+        }
+    }
+    annotation[which(annotation == "Intergenic")] = "Distal Intergenic"
 
     downstreamIndex <- dd2 > 0 & dd2 < dsd
     detailGenomicAnnotation[downstreamIndex, "downstream"] <- TRUE


### PR DESCRIPTION
This pull request is to fix #112,  #121,  #139, which reflects the same problem having two parts.

The first  part is that when change the options(ChIPseeker.downstreamDistance = 500), the marker in the picture change but the ratio of `Downstream(<=N)` do not change.The reason is because https://github.com/YuLab-SMU/ChIPseeker/issues/112#issuecomment-818660296.
```
library(ChIPseeker)
library(TxDb.Hsapiens.UCSC.hg19.knownGene)
txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene

files <- getSampleFiles()
peak <- readPeakFile(files[[4]])

options(ChIPseeker.downstreamDistance = 3000)
getOption('ChIPseeker.downstreamDistance')
x <- annotatePeak(peak,
                  tssRegion = c(-1000,1000),
                  TxDb = txdb)
plotAnnoPie(x,cex = 0.7)
```
![distance3000](https://user-images.githubusercontent.com/78794151/115099740-7e585500-9f6a-11eb-95e2-61ca67c2d387.png)
```
options(ChIPseeker.downstreamDistance = 500)
getOption('ChIPseeker.downstreamDistance')
x1 <- annotatePeak(peak,
                  tssRegion = c(-1000,1000),
                  TxDb = txdb)
plotAnnoPie(x1,cex = 0.7)
```
![distance500](https://user-images.githubusercontent.com/78794151/115099766-a34cc800-9f6a-11eb-903c-be4c730162a2.png)
As it shows above the marker is changed, but the ratio do not change.

The second part is the misuse of `precede()`, which reported in #139. This problem causes the different between the result of `annotatePeak` and `peakAnno@detailGenomicAnnotation$downstream`.
```
# issue139
library(ChIPseeker)
library(TxDb.Hsapiens.UCSC.hg19.knownGene)
TxDb <- TxDb.Hsapiens.UCSC.hg19.knownGene

files <- getSampleFiles()
peakAnno <- annotatePeak(files[[2]], tssRegion=c(-500, 0),
                         TxDb=TxDb, 
                         level = "gene")

# According to the peakAnno result, there will be about 20 peaks in the downstream. 
> peakAnno
Annotated peaks generated by ChIPseeker
2296/2296  peaks were annotated
Genomic Annotation Summary:
             Feature  Frequency
9           Promoter  0.7404181
4             5' UTR  0.6533101
3             3' UTR  1.5243902
1           1st Exon  0.4355401
7         Other Exon  2.6567944
2         1st Intron 14.5905923
8       Other Intron 31.6637631
6 Downstream (<=300)  0.8710801
5  Distal Intergenic 46.8641115

# But according to the result below, it seems no peak locating downstream
> sum(peakAnno@detailGenomicAnnotation$downstream)
[1] 0
```
the reason is because https://github.com/YuLab-SMU/ChIPseeker/issues/139#issuecomment-818673319.

After doing the changing, the two parts are corrected.
```
options(ChIPseeker.downstreamDistance = 3000)
getOption('ChIPseeker.downstreamDistance')
x <- annotatePeak(peak,
                  tssRegion = c(-1000,1000),
                  TxDb = txdb)
plotAnnoPie(x,cex = 0.7)
```
![4](https://user-images.githubusercontent.com/78794151/115099852-3980ee00-9f6b-11eb-86bc-211a237793ef.png)
The reason that ratio changes from 1.13% to 1.05%  is that I use `follow()` to replace `precede()`. Different functions get different result.
```
options(ChIPseeker.downstreamDistance = 500)
getOption('ChIPseeker.downstreamDistance')
x1 <- annotatePeak(peak,
                   tssRegion = c(-1000,1000),
                   TxDb = txdb)
plotAnnoPie(x1,cex = 0.7)
```
![3](https://user-images.githubusercontent.com/78794151/115099925-c3c95200-9f6b-11eb-8c61-c2585fcb30ca.png)

All that above is what the PR do.

