### PR TITLE
debug for swaping the upstream and downstream in the negative strand

### DIFF
--- a/R/tagMatrix.R
+++ b/R/tagMatrix.R
@@ -113,8 +113,12 @@ getBioRegion <- function(TxDb=NULL,
     return(regions)
   }
   
+  ## issue and code obtained from Chen Ting(NIH/NCI)
+  start_site <- ifelse(strand(regions) == "+",coordinate-upstream, coordinate-downstream)
+  end_site <- ifelse(strand(regions) == "+", coordinate+downstream, coordinate+upstream)
+  
   bioRegion <- GRanges(seqnames=seqnames(regions),
-                       ranges=IRanges(coordinate-upstream, coordinate+downstream),
+                       ranges=IRanges(start_site, end_site),
                        strand=strand(regions))
   bioRegion <- unique(bioRegion)
   


### PR DESCRIPTION
<img width="441" alt="1" src="https://user-images.githubusercontent.com/78794151/146219154-d4ff3391-29dd-4162-8d5f-ce8a93d091c5.PNG">

In the ChIPseeker code method of calculating upstream and downstream
```
TSS/TTS - upstream ~ TSS/TTS + downstream(regardless of +/- strand)
```
According to picture above, the correct method should be
```
+ :   TSS/TTS -  upstream ~ TSS/TTS + downstream
-  :   TSS/TTS - downstream  ~ TSS/TTS + upstream
```