### PR TITLE
correct typo in README.Rmd

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -1,4 +1,4 @@
-/al---
+---
 output:
   md_document:
     variant: gfm


### PR DESCRIPTION
correct small typo in README.Rmd, 
but can not re-render README.md without knowing how to install `ypages` packages.