### PR TITLE
call geom_blank() when there is no peak.

### DIFF
--- a/R/covplot.R
+++ b/R/covplot.R
@@ -52,15 +52,20 @@ covplot <- function(peak, weightCol=NULL,
     
     chr <- start <- end <- value <- .id <- NULL
    
-    p <- ggplot(tm, aes(start, value))
-    ## p <- p + geom_segment(aes(x=start, y=0, xend=end, yend= value))
-    if (isList) {
-        p <- p + geom_rect(aes(xmin=start, ymin=0, xmax=end, ymax=value, fill=.id, color=.id)) 
+    if(length(tm$chr) == 0){
+        p <- ggplot(data.frame(x = 1)) + geom_blank()
     } else {
-        p <- p + geom_rect(aes(xmin=start, ymin=0, xmax=end, ymax=value), fill='black', color='black')
-    }
-    if(length(unique(tm$chr)) > 1) {
-        p <- p + facet_grid(chr ~., scales="free")
+        p <- ggplot(tm, aes(start, value))
+        
+        ## p <- p + geom_segment(aes(x=start, y=0, xend=end, yend= value))
+        if (isList) {
+            p <- p + geom_rect(aes(xmin=start, ymin=0, xmax=end, ymax=value, fill=.id, color=.id)) 
+        } else {
+            p <- p + geom_rect(aes(xmin=start, ymin=0, xmax=end, ymax=value), fill='black', color='black')
+        }
+        if(length(unique(tm$chr)) > 1) {
+            p <- p + facet_grid(chr ~., scales="free")
+        }
     }
     
     p <- p + theme_classic()


### PR DESCRIPTION
您好，昨天我在使用ChIPseeker包的covplot函数对一组ChIP-seq的样本进行可视化时发现，当我指定了chrs和xlim这两个参数，且此范围内一个peak也没有的时候函数并不返回一张空图，而是出现了一些与ggplot2有关的报错信息，而且调用此函数进行批量作图的for循环也被中止了（我觉得这可能会为批量处理数据带来不便）。
我认为这可能是在使用ggplot2绘图时传入了一个空对象的原因，并尝试对其进行了修改，在作图之前先判断peak的数量是否为0，如果为0则调用geom_blank()生成一张空图。
我尝试用修改后的代码重新处理之前报错的样本，似乎达到了预期的目标。