### PR TITLE
add function for covplot()

### DIFF
--- a/man/covplot.Rd
+++ b/man/covplot.Rd
@@ -12,7 +12,8 @@ covplot(
   title = "ChIP Peaks over Chromosomes",
   chrs = NULL,
   xlim = NULL,
-  lower = 1
+  lower = 1,
+  fill_color = NULL
 )
 }
 \arguments{
@@ -31,6 +32,8 @@ covplot(
 \item{xlim}{ranges to plot, default is whole chromosome}
 
 \item{lower}{lower cutoff of coverage signal}
+
+\item{fill_color}{specify the color for the plot. Order matters}
 }
 \value{
 ggplot2 object


### PR DESCRIPTION
According to issue #185 , I add function to specify the color for the covplot().
```
devtools::install_github("MingLi-929/ChIPseeker",build_vignettes = T)

peak <- getSampleFiles()

## the order maters
covplot(peak[4:5],fill_color = c('black','red'))
```
![3](https://user-images.githubusercontent.com/78794151/166212285-ea05b295-1002-4a0d-80f4-f6e08497722b.png)
```
# change the order of color
covplot(peak[4:5],fill_color = c('red','black'))
```
![4](https://user-images.githubusercontent.com/78794151/166212363-d058d2b8-4c19-4cb9-a154-6a1a1fbd5e06.png)
```
## it can also specify for single sample
covplot(peak[[4]],fill_color = c('red'))
```
![5](https://user-images.githubusercontent.com/78794151/166212453-60d9323c-6a0c-4ef7-8a92-56e1c1202da6.png)
```
# the color can be specify in hex number
covplot(peak[4:5],fill_color = c('#00FFFF','#FF4040'))
```
![6](https://user-images.githubusercontent.com/78794151/166212524-17003755-7583-4663-b508-765d1e35d083.png)
